### PR TITLE
:sparkles: feat: verifica as chaves depois do print

### DIFF
--- a/Analisador.py
+++ b/Analisador.py
@@ -82,6 +82,29 @@ def analisarPalavra(palavra):
             token = enumToken.getByLexeme(lexema)
             tokens.append(token.code)
             lexemas.append({"lexema": token.lexeme, "linha": nrLinha})
+
+            if lexema == 'print':
+                j = i
+                abriu = 0
+                fechou = 0
+                while j < len(palavra) and palavra[j] != ';':
+                    if palavra[j] == '{':
+                        abriu += 1
+                    elif palavra[j] == '}':
+                        fechou += 1
+                    j += 1
+
+                if abriu == 0:
+                    erros.append({"linha": nrLinha, "lexema": "print", "erro": "Faltou chave de abertura"})
+                if fechou == 0:
+                    erros.append({"linha": nrLinha, "lexema": "print", "erro": "Faltou chave de fechamento"})
+                if abriu > 1:
+                    erros.append({"linha": nrLinha, "lexema": "print", "erro": "Chave de abertura extra"})
+                if fechou > 1:
+                    erros.append({"linha": nrLinha, "lexema": "print", "erro": "Chave de fechamento extra"})
+                if fechou > abriu:
+                    erros.append({"linha": nrLinha, "lexema": "print", "erro": "Chave fechando sem correspondente"})
+
             lexema = ""
         elif (len(palavra)>i+1 and (palavra[i+1] in delimitadores or palavra[i+1] in delimitadoresPular or palavra[i+1] =='.')) or len(palavra)==i+1:
             if(len(palavra)>i+1 and palavra[i+1] == '.' and lexema.isdigit() and len(palavra)>i+2 and palavra[i+2].isdigit()):
@@ -125,8 +148,6 @@ def analisarPalavra(palavra):
                     if not podeIdent and tokens[len(tokens)-2] == token[0]:
                         erros.append({"linha": nrLinha, "lexema": lexemas[len(tokens)-2]["lexema"] + " " + lexema, "erro": "Identificador não pode ter espaço entre letras"})
                     podeIdent = False
-                
-                
 
     if(esperaFechamentoLiteral):
         erros.append({"linha": lexemas[len(lexemas)-1]['linha'], "lexema": "'", "erro": "Literal não fechado"})

--- a/exemplos/print.txt
+++ b/exemplos/print.txt
@@ -1,0 +1,19 @@
+program testePrintErrado;
+var nome: string;
+begin
+    nome := "Eduardo";
+
+    print{'Olá, ', nome};
+    print{'Nome: ', nome};
+    print{'Saída 1'};
+    print{'Mensagem'};
+
+    print'Faltou chave de abertura', nome};
+    print{'Faltou chave de fechamento', nome;
+    print{{'Chave extra'};
+    print{'Chave fechada duas vezes'}};
+    print{'Aberta e depois extra'}; };
+
+    print{'Tudo certo aqui'};
+    print{"Outro print certo"};
+end.


### PR DESCRIPTION
A verificação cobre casos gerais de inconsistência nas chaves após o `print`.  

não adicionei a validação do: **print{'Aberta e depois extra'}; };** pois acredito que ela será em outra parte do código.